### PR TITLE
Add TypeScript interfaces for page data

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -2,18 +2,44 @@
 
 import React from 'react'
 import { motion } from 'framer-motion'
-import { Download, MapPin, Calendar, Mail, Phone, Globe, Award, Book, Coffee } from 'lucide-react'
+import { Download, MapPin, Calendar, Mail, Phone, Globe, Award, Book, Coffee, type LucideIcon } from 'lucide-react'
 import Link from 'next/link'
 
+interface Technology {
+  category: string
+  skills: string[]
+}
+
+interface Experience {
+  title: string
+  company: string
+  period: string
+  description: string
+  achievements: string[]
+}
+
+interface Education {
+  degree: string
+  school: string
+  period: string
+  description: string
+}
+
+interface PersonalStat {
+  icon: LucideIcon
+  label: string
+  value: string
+}
+
 const AboutPage = () => {
-  const technologies = [
+  const technologies: Technology[] = [
     { category: 'Frontend', skills: ['React', 'Next.js', 'TypeScript', 'Tailwind CSS', 'Framer Motion'] },
     { category: 'Backend', skills: ['Node.js', 'Express', 'PostgreSQL', 'MongoDB', 'REST APIs'] },
     { category: 'Tools', skills: ['Git', 'Docker', 'VS Code', 'Figma', 'Adobe Creative Suite'] },
     { category: 'Cloud', skills: ['AWS', 'Vercel', 'Netlify', 'Firebase', 'DigitalOcean'] },
   ]
 
-  const experience = [
+  const experience: Experience[] = [
     {
       title: 'Senior Full-Stack Developer',
       company: 'TechCorp Solutions',
@@ -37,7 +63,7 @@ const AboutPage = () => {
     }
   ]
 
-  const education = [
+  const education: Education[] = [
     {
       degree: 'Bachelor of Computer Science',
       school: 'University of Technology',
@@ -52,7 +78,7 @@ const AboutPage = () => {
     }
   ]
 
-  const personalStats = [
+  const personalStats: PersonalStat[] = [
     { icon: Coffee, label: 'Cups of Coffee', value: '1000+' },
     { icon: Book, label: 'Projects Completed', value: '50+' },
     { icon: Award, label: 'Happy Clients', value: '25+' },

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -5,10 +5,30 @@ import { motion, AnimatePresence } from 'framer-motion'
 import { ExternalLink, Github, Filter, Star, Calendar, ArrowRight } from 'lucide-react'
 import Link from 'next/link'
 
+interface Category {
+  id: string
+  label: string
+}
+
+interface Project {
+  id: number
+  title: string
+  category: string
+  description: string
+  image: string
+  technologies: string[]
+  liveUrl: string
+  githubUrl: string
+  featured: boolean
+  date: string
+  client: string
+  results: string[]
+}
+
 const ProjectsPage = () => {
   const [filter, setFilter] = useState('all')
 
-  const categories = [
+  const categories: Category[] = [
     { id: 'all', label: 'All Projects' },
     { id: 'web', label: 'Web Apps' },
     { id: 'ecommerce', label: 'E-Commerce' },
@@ -16,7 +36,7 @@ const ProjectsPage = () => {
     { id: 'mobile', label: 'Mobile Apps' }
   ]
 
-  const projects = [
+  const projects: Project[] = [
     {
       id: 1,
       title: 'E-Commerce Platform',

--- a/app/services/page.tsx
+++ b/app/services/page.tsx
@@ -2,11 +2,31 @@
 
 import React from 'react'
 import { motion } from 'framer-motion'
-import { Code, Palette, Zap, Search, Globe, Shield, ArrowRight, Check } from 'lucide-react'
+import { Code, Palette, Zap, Search, Globe, Shield, ArrowRight, Check, type LucideIcon } from 'lucide-react'
 import Link from 'next/link'
 
+interface Service {
+  icon: LucideIcon
+  title: string
+  description: string
+  features: string[]
+  price: string
+  popular: boolean
+}
+
+interface ProcessStep {
+  step: string
+  title: string
+  description: string
+}
+
+interface FAQ {
+  question: string
+  answer: string
+}
+
 const ServicesPage = () => {
-  const services = [
+  const services: Service[] = [
     {
       icon: Code,
       title: 'Web Development',
@@ -57,7 +77,7 @@ const ServicesPage = () => {
     }
   ]
 
-  const process = [
+  const process: ProcessStep[] = [
     {
       step: '01',
       title: 'Discovery & Strategy',
@@ -80,7 +100,7 @@ const ServicesPage = () => {
     }
   ]
 
-  const faqs = [
+  const faqs: FAQ[] = [
     {
       question: 'How long does a typical project take?',
       answer: 'Project timelines vary based on complexity, but most websites take 4-8 weeks from start to finish. I\'ll provide a detailed timeline during our initial consultation.'


### PR DESCRIPTION
## Summary
- define interfaces for technologies, experience, education and personal stats on About page
- apply the same approach for services and projects pages
- type arrays with the new interfaces

## Testing
- `npm install`
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6850108fd744832092c2f781676fb44c