### PR TITLE
feat: Add profile image to About page hero section

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -4,6 +4,7 @@ import React from 'react'
 import { motion } from 'framer-motion'
 import { Download, MapPin, Calendar, Mail, Phone, Globe, Award, Book, Coffee, type LucideIcon } from 'lucide-react'
 import Link from 'next/link'
+import Image from 'next/image'
 
 interface Technology {
   category: string
@@ -134,8 +135,14 @@ const AboutPage = () => {
               transition={{ duration: 0.8, delay: 0.2 }}
             >
               <div className="w-80 h-80 bg-brand-surface/10 backdrop-blur-md rounded-3xl mx-auto flex items-center justify-center">
-                <div className="w-64 h-64 bg-gradient-to-br from-brand-accent to-brand-strong rounded-2xl flex items-center justify-center">
-                  <span className="text-6xl font-bold text-brand-base">DS</span>
+                <div className="w-64 h-64 bg-gradient-to-br from-brand-accent to-brand-strong rounded-2xl flex items-center justify-center overflow-hidden">
+                  <Image
+                    src="/assets/dasun.png"
+                    alt="Dasun"
+                    width={256}
+                    height={256}
+                    className="rounded-full object-cover"
+                  />
                 </div>
               </div>
             </motion.div>


### PR DESCRIPTION
Replaced the placeholder 'DS' text with an image of Dasun in the hero section of the About page.

The image `dasun.png` from the `public/assets/` directory is used. It is styled to be circular and fit within the existing 256x256px container. Ensured proper styling for circular clipping within its parent container.