### PR TITLE
fix: Update profile image border radius to match placeholder

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -141,7 +141,7 @@ const AboutPage = () => {
                     alt="Dasun"
                     width={256}
                     height={256}
-                    className="rounded-full object-cover"
+                    className="rounded-2xl object-cover"
                   />
                 </div>
               </div>


### PR DESCRIPTION
Changed the border radius of the profile image on the About page hero section from circular (`rounded-full`) to `rounded-2xl`.

This change aligns the image's shape with the surrounding placeholder element as per your feedback.