### PR TITLE
feat: Increase profile image and container size by 25%

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -4,6 +4,7 @@ import React from 'react'
 import { motion } from 'framer-motion'
 import { Download, MapPin, Calendar, Mail, Phone, Globe, Award, Book, Coffee, type LucideIcon } from 'lucide-react'
 import Link from 'next/link'
+import Image from 'next/image'
 
 interface Technology {
   category: string
@@ -133,9 +134,15 @@ const AboutPage = () => {
               animate={{ opacity: 1, x: 0 }}
               transition={{ duration: 0.8, delay: 0.2 }}
             >
-              <div className="w-80 h-80 bg-brand-surface/10 backdrop-blur-md rounded-3xl mx-auto flex items-center justify-center">
-                <div className="w-64 h-64 bg-gradient-to-br from-brand-accent to-brand-strong rounded-2xl flex items-center justify-center">
-                  <span className="text-6xl font-bold text-brand-base">DS</span>
+              <div className="w-100 h-100 bg-brand-surface/10 backdrop-blur-md rounded-3xl mx-auto flex items-center justify-center">
+                <div className="w-80 h-80 bg-gradient-to-br from-brand-accent to-brand-strong rounded-2xl flex items-center justify-center overflow-hidden">
+                  <Image
+                    src="/assets/dasun.png"
+                    alt="Dasun"
+                    width={320}
+                    height={320}
+                    className="rounded-2xl object-cover"
+                  />
                 </div>
               </div>
             </motion.div>


### PR DESCRIPTION
I've increased the size of the profile image and its surrounding containers in the About page hero section.

- The outer container was changed from w-80 h-80 (320px) to w-100 h-100 (400px).
- The inner image container was changed from w-64 h-64 (256px) to w-80 h-80 (320px).
- The Image component dimensions were updated from 256x256 to 320x320.

This addresses your feedback to make the image and its placeholder appear larger.