### PR TITLE
feat: Enhance profile image section with new animations and styling

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -4,6 +4,7 @@ import React from 'react'
 import { motion } from 'framer-motion'
 import { Download, MapPin, Calendar, Mail, Phone, Globe, Award, Book, Coffee, type LucideIcon } from 'lucide-react'
 import Link from 'next/link'
+import Image from 'next/image'
 
 interface Technology {
   category: string
@@ -133,9 +134,25 @@ const AboutPage = () => {
               animate={{ opacity: 1, x: 0 }}
               transition={{ duration: 0.8, delay: 0.2 }}
             >
-              <div className="w-80 h-80 bg-brand-surface/10 backdrop-blur-md rounded-3xl mx-auto flex items-center justify-center">
-                <div className="w-64 h-64 bg-gradient-to-br from-brand-accent to-brand-strong rounded-2xl flex items-center justify-center">
-                  <span className="text-6xl font-bold text-brand-base">DS</span>
+              <motion.div
+                className="w-100 h-100 bg-brand-surface/20 backdrop-blur-lg rounded-3xl mx-auto flex items-center justify-center"
+                initial={{ opacity: 0, scale: 0.95 }}
+                animate={{ opacity: 1, scale: [1, 1.01, 1], y: [0, -4, 0] }}
+                transition={{ duration: 0.5, ease: "easeOut", scale: { repeat: Infinity, duration: 7, ease: "easeInOut" }, y: { repeat: Infinity, duration: 7, ease: "easeInOut", delay: 3.5 } }}
+              >
+                <motion.div
+                  className="w-80 h-80 bg-gradient-to-br from-brand-accent to-brand-strong rounded-2xl flex items-center justify-center overflow-hidden"
+                  initial={{ opacity: 0, scale: 0.9 }}
+                  animate={{ opacity: 1, scale: [1, 1.005, 1], y: [0, 2, 0] }}
+                  transition={{ delay: 0.2, duration: 0.5, ease: "easeOut", scale: { repeat: Infinity, duration: 5, ease: "easeInOut" }, y: { repeat: Infinity, duration: 5, ease: "easeInOut", delay: 2.5 } }}
+                >
+                  <Image
+                    src="/assets/dasun.png"
+                    alt="Dasun"
+                    width={320}
+                    height={320}
+                    className="rounded-2xl object-cover"
+                  />
                 </div>
               </div>
             </motion.div>


### PR DESCRIPTION
This commit implements the following changes to the profile image section on the About page:

1.  Backdrop Styling:
    - Adjusted the background opacity from bg-brand-surface/10 to bg-brand-surface/20.
    - Increased the backdrop blur from backdrop-blur-md to backdrop-blur-lg for a more refined shader effect.

2.  Entrance Animations:
    - Added a fade-in and scale-up entrance animation to the backdrop.
    - Added a similar fade-in and scale-up entrance animation to the image container, slightly delayed after the backdrop, for a staggered effect.

3.  Continuous Subtle Animations:
    - Implemented a gentle, continuous floating (y-axis movement) and scaling animation for the backdrop.
    - Added a similar, but slightly offset in timing and movement, continuous animation to the image container to create a dynamic, layered feel.

These changes address your feedback to improve the visual appeal and engagement of the hero image presentation using Framer Motion.