### PR TITLE
Embed Rive animation behind hero section

### DIFF
--- a/components/RiveComponent.tsx
+++ b/components/RiveComponent.tsx
@@ -35,7 +35,7 @@ export default function RiveHero() {
   }, [rive]);
 
   return (
-    <div ref={containerRef} className="absolute inset-0 w-screen h-full">
+    <div ref={containerRef} className="absolute inset-0 w-full h-full">
       <RiveComponent className="w-full h-full" />
     </div>
   );

--- a/components/sections/HeroSection.tsx
+++ b/components/sections/HeroSection.tsx
@@ -9,23 +9,17 @@ import styles from '../../styles/HeroSection.module.css'
 const HeroSection = () => {
   return (
     <>
-      {/* Canvas section for Rive animation */}
+      {/* Hero section with Rive background */}
       <section
-        id="canvas"
-        className="w-screen h-screen relative overflow-hidden"
+        id="hero"
+        className="relative w-full h-screen flex items-center overflow-hidden"
+        style={{ backgroundColor: '#08080D' }}
       >
         {/* Rive animation */}
         <div className={styles.riveContainer}>
           <RiveHero />
         </div>
-      </section>
 
-      {/* Hero section */}
-      <section
-        id="hero"
-        className="w-full flex items-center relative"
-        style={{ backgroundColor: '#08080D' }}
-      >
         {/* Hero content */}
         <div className="max-w-3xl mx-auto px-6 space-y-6 text-left relative z-10">
           <motion.h1

--- a/styles/HeroSection.module.css
+++ b/styles/HeroSection.module.css
@@ -1,9 +1,15 @@
 .rive-container {
-	position: absolute;
-	top: 0;
-	left: 0;
-	width: 100vw;
-	height: auto;
-	overflow: hidden;
-	z-index: -1;
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        overflow: hidden;
+        z-index: -1;
+}
+
+@media (max-width: 768px) {
+        .rive-container {
+                height: 100vh;
+        }
 }


### PR DESCRIPTION
## Summary
- place Rive animation directly inside hero section
- ensure animation container fills hero section and is full height on mobile
- adjust Rive component width

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852b5fbbfd883209bcb7a6c4e970c13