### PR TITLE
Add project gallery with details pages

### DIFF
--- a/app/projects/[slug]/page.tsx
+++ b/app/projects/[slug]/page.tsx
@@ -1,0 +1,37 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { projects, getProject } from "../../../lib/projects";
+
+export async function generateStaticParams() {
+  return projects.map((p) => ({ slug: p.slug }));
+}
+
+export default function ProjectPage({ params }: { params: { slug: string } }) {
+  const project = getProject(params.slug);
+  if (!project) {
+    notFound();
+  }
+  return (
+    <div className="min-h-screen py-20 bg-brand-base text-white">
+      <div className="max-w-3xl mx-auto px-6 space-y-6">
+        <h1
+          className="text-3xl md:text-4xl font-bold"
+          style={{ color: "#FEA485" }}
+        >
+          {project.title}
+        </h1>
+        <img
+          src={project.image}
+          alt={project.title}
+          className="w-full rounded-2xl"
+        />
+        <p className="whitespace-pre-line text-white text-sm">
+          {project.description}
+        </p>
+        <Link href="/" className="text-brand-accent">
+          &larr; Back to Home
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/components/sections/ProjectsSection.tsx
+++ b/components/sections/ProjectsSection.tsx
@@ -1,118 +1,62 @@
-'use client'
+"use client";
 
-import React, { useState } from 'react'
-import { motion } from 'framer-motion'
-
-const projects = [
-	{
-		title: 'Wavenet Website',
-		description: `Overview:
-As part of Wavenet’s in-house marketing team, I led the revamp of the official GlobalWavenet website—a core digital asset representing multiple global business units in telecom software.
-
-What I Worked On:
-- Planned and executed a complete site redesign on webflow focused on performance, accessibility, and lead generation.
-- Migrated content and restructured pages for improved SEO and user navigation.
-- Integrated GA4 and Google Tag Manager to track user interactions and conversion events.
-- Optimized all media, forms, and landing pages to support marketing campaigns.
-- Worked closely with designers and content creators to maintain brand consistency.
-
-Impact:
-Significantly improved page load times, enhanced SEO visibility, and boosted marketing campaign performance through data-driven iteration.`,
-		url: 'https://www.globalwavenet.com/',
-	},
-	{
-		title: 'SaaS Dashboard',
-		description:
-			'A comprehensive dashboard for SaaS businesses with analytics and billing integration.',
-		url: 'https://example.com',
-	},
-	{
-		title: 'Learning Management System',
-		description: 'A full featured LMS with video streaming and interactive quizzes.',
-		url: 'https://example.com',
-	},
-]
+import Link from "next/link";
+import { motion } from "framer-motion";
+import { projects } from "../../lib/projects";
 
 const ProjectsSection = () => {
-	const [current, setCurrent] = useState(0)
-	const total = projects.length
+  return (
+    <section id="projects" className="py-20 bg-brand-base text-white">
+      <div className="max-w-5xl mx-auto px-6 text-center">
+        <motion.h2
+          initial={{ opacity: 0, y: 30 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true }}
+          transition={{ duration: 0.8 }}
+          className="text-3xl md:text-4xl font-bold text-center mb-10"
+          style={{ color: "#FEA485" }}
+        >
+          Projects
+        </motion.h2>
+        <motion.div
+          className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6"
+          initial="hidden"
+          whileInView="visible"
+          viewport={{ once: true }}
+          variants={{
+            hidden: {},
+            visible: { transition: { staggerChildren: 0.1 } },
+          }}
+        >
+          {projects.map((project) => (
+            <motion.div
+              key={project.slug}
+              variants={{
+                hidden: { opacity: 0, y: 20 },
+                visible: { opacity: 1, y: 0 },
+              }}
+            >
+              <Link
+                href={`/projects/${project.slug}`}
+                className="block group relative rounded-2xl overflow-hidden"
+              >
+                <img
+                  src={project.image}
+                  alt={project.title}
+                  className="w-full h-60 object-cover"
+                />
+                <div className="absolute inset-0 bg-brand-base/80 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity">
+                  <span className="text-white font-semibold">
+                    {project.title}
+                  </span>
+                </div>
+              </Link>
+            </motion.div>
+          ))}
+        </motion.div>
+      </div>
+    </section>
+  );
+};
 
-	const prevSlide = () =>
-		setCurrent((prev) => (prev === 0 ? total - 1 : prev - 1))
-	const nextSlide = () =>
-		setCurrent((prev) => (prev === total - 1 ? 0 : prev + 1))
-
-	return (
-		<section id="projects" className="py-20 bg-brand-base text-white">
-			<div className="max-w-3xl mx-auto px-6 text-center">
-				<motion.h2
-					initial={{ opacity: 0, y: 30 }}
-					whileInView={{ opacity: 1, y: 0 }}
-					viewport={{ once: true }}
-					transition={{ duration: 0.8 }}
-					className="text-3xl md:text-4xl font-bold text-center mb-10"
-					style={{ color: '#FEA485' }}
-				>
-					Projects
-				</motion.h2>
-				<div className="relative flex items-center justify-center">
-					<button
-						onClick={prevSlide}
-						className="absolute left-[-6rem] z-10 bg-[#FEA485] text-white rounded-full w-14 h-14 flex items-center justify-center shadow-md hover:bg-[#ff8c5a] transition-colors duration-300"
-					>
-						&#8592;
-					</button>
-					<div className="w-full flex justify-center">
-						<motion.a
-							key={current}
-							href={projects[current].url}
-							target="_blank"
-							rel="noopener noreferrer"
-							className="flex flex-col md:flex-row bg-brand-surface rounded-2xl p-12 w-full max-w-4xl items-center shadow-lg transition-shadow min-h-[425px]"
-							initial={{ opacity: 0, y: 20 }}
-							animate={{ opacity: 1, y: 0 }}
-							transition={{ duration: 0.6 }}
-						>
-							{/* Image placeholder */}
-							<div className="w-80 h-80 bg-gray-700 rounded-2xl flex-shrink-0 mb-8 md:mb-0 md:mr-12 flex items-center justify-center">
-								<span className="text-gray-400 text-lg">Image</span>
-							</div>
-							{/* Content */}
-							<div className="flex-1 text-left">
-								<h3 className="text-2xl font-semibold mb-4">
-									{projects[current].title}
-								</h3>
-								<p className="text-white text-xs leading-relaxed whitespace-pre-line mb-4">
-									{projects[current].description}
-								</p>
-								<span className="text-sm text-brand-accent">
-									View Project &rarr;
-								</span>
-							</div>
-						</motion.a>
-					</div>
-					<button
-						onClick={nextSlide}
-						className="absolute right-[-6rem] z-10 bg-[#FEA485] text-white rounded-full w-14 h-14 flex items-center justify-center shadow-md hover:bg-[#ff8c5a] transition-colors duration-300"
-					>
-						&#8594;
-					</button>
-				</div>
-				<div className="flex justify-center mt-4 gap-2">
-					{projects.map((_, idx) => (
-						<button
-							key={idx}
-							onClick={() => setCurrent(idx)}
-							className={`w-3 h-3 rounded-full ${
-								current === idx ? 'bg-[#FEA485]' : 'bg-gray-500'
-							} transition-colors`}
-							aria-label={`Go to slide ${idx + 1}`}
-						/>
-					))}
-				</div>
-			</div>
-		</section>
-	)
-}
-
-export default ProjectsSection
+export default ProjectsSection;

--- a/lib/projects.ts
+++ b/lib/projects.ts
@@ -1,0 +1,48 @@
+export interface Project {
+  slug: string;
+  title: string;
+  shortDescription: string;
+  description: string;
+  image: string;
+}
+
+export const projects: Project[] = [
+  {
+    slug: "wavenet-website",
+    title: "Wavenet Website",
+    shortDescription: "Corporate site redesign with SEO focus",
+    description: `Overview:
+As part of Wavenet’s in-house marketing team, I led the revamp of the official GlobalWavenet website—a core digital asset representing multiple global business units in telecom software.
+
+What I Worked On:
+- Planned and executed a complete site redesign on webflow focused on performance, accessibility, and lead generation.
+- Migrated content and restructured pages for improved SEO and user navigation.
+- Integrated GA4 and Google Tag Manager to track user interactions and conversion events.
+- Optimized all media, forms, and landing pages to support marketing campaigns.
+- Worked closely with designers and content creators to maintain brand consistency.
+
+Impact:
+Significantly improved page load times, enhanced SEO visibility, and boosted marketing campaign performance through data-driven iteration.`,
+    image: "/assets/projects/wavenet-website.svg",
+  },
+  {
+    slug: "saas-dashboard",
+    title: "SaaS Dashboard",
+    shortDescription: "Analytics and billing dashboard",
+    description:
+      "A comprehensive dashboard for SaaS businesses with analytics and billing integration.",
+    image: "/assets/projects/saas-dashboard.svg",
+  },
+  {
+    slug: "learning-management-system",
+    title: "Learning Management System",
+    shortDescription: "Video streaming and quizzes",
+    description:
+      "A full featured LMS with video streaming and interactive quizzes.",
+    image: "/assets/projects/lms.svg",
+  },
+];
+
+export function getProject(slug: string): Project | undefined {
+  return projects.find((p) => p.slug === slug);
+}

--- a/public/assets/projects/lms.svg
+++ b/public/assets/projects/lms.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="400">
+  <rect width="600" height="400" fill="#161E2F"/>
+</svg>

--- a/public/assets/projects/saas-dashboard.svg
+++ b/public/assets/projects/saas-dashboard.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="400">
+  <rect width="600" height="400" fill="#242F49"/>
+</svg>

--- a/public/assets/projects/wavenet-website.svg
+++ b/public/assets/projects/wavenet-website.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="400">
+  <rect width="600" height="400" fill="#384358"/>
+</svg>


### PR DESCRIPTION
## Summary
- create placeholder project images
- define project metadata in `lib/projects.ts`
- replace slider with grid gallery in ProjectsSection
- add dynamic `[slug]` pages for project details

## Testing
- `npm run lint` *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6853ece2291c83209cf885bdc2c6458c