### PR TITLE
Fix page params type in project page

### DIFF
--- a/app/projects/[slug]/page.tsx
+++ b/app/projects/[slug]/page.tsx
@@ -6,8 +6,13 @@ export async function generateStaticParams() {
   return projects.map((p) => ({ slug: p.slug }));
 }
 
-export default function ProjectPage({ params }: { params: { slug: string } }) {
-  const project = getProject(params.slug);
+export default async function ProjectPage({
+  params,
+}: {
+  params: Promise<{ slug: string }>
+}) {
+  const { slug } = await params
+  const project = getProject(slug);
   if (!project) {
     notFound();
   }


### PR DESCRIPTION
## Summary
- update dynamic project page to use asynchronous params

## Testing
- `npx tsc --noEmit`
- `npm run build` *(fails: Failed to fetch font `Inter`)*

------
https://chatgpt.com/codex/tasks/task_e_68553e31c6bc8320b99af34c176ead3d